### PR TITLE
[Process Doc Update]: Add README for OctoAcme Project Management Docs — links & summary included

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,54 @@
+# OctoAcme Project Management Docs — Overview & Index
+
+This folder contains OctoAcme's project management process documentation. Use this README as the entry point for project-level processes, roles, and key artifacts.
+
+Purpose
+- Provide a centralized entry point for project management practices at OctoAcme.
+- Summarize core processes and lifecycle stages for rapid orientation.
+- Link directly to detailed documentation for each workflow, guide, and role.
+
+Project Management Principles
+- Customer-first: deliver value iteratively with clear ownership and measurable outcomes.
+- Iterative delivery: ship small, testable increments and validate outcomes.
+- Clear ownership: each project has a named Project Manager (PM) and Product Lead.
+- Lightweight, actionable documentation: keep guidance concise and practical.
+- Visible decision-making and risk tracking: record trade-offs and escalation paths.
+
+Lifecycle at a glance
+1. Initiation — Define the problem, stakeholders, and success metrics (Project One‑pager).
+2. Planning — Build backlog, estimate, identify dependencies and risks, and create a release plan.
+3. Execution — Deliver in increments, track progress, enforce quality gates, and test.
+4. Release — Deploy using standardized checks, run smoke tests, and communicate the rollout.
+5. Retrospective — Capture learnings, track action items, and iterate the process.
+
+Documentation Index
+- Project Management Overview — provides the high-level approach and roles  
+  https://github.com/rhythmpatel/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-project-management-overview.md
+
+- Project Initiation Guide — problem validation, one‑pager, and decision gate  
+  https://github.com/rhythmpatel/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-project-initiation.md
+
+- Project Planning — backlog, estimates, DoD, and release planning  
+  https://github.com/rhythmpatel/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-project-planning.md
+
+- Execution & Tracking — team rhythm, PR workflow, quality and reporting  
+  https://github.com/rhythmpatel/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-execution-and-tracking.md
+
+- Risk Management & Communication — risk register, stakeholder comms, escalation  
+  https://github.com/rhythmpatel/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-risks-and-communication.md
+
+- Release & Deployment Guide — release types, pre-release checks, rollback playbook  
+  https://github.com/rhythmpatel/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-release-and-deployment.md
+
+- Retrospective & Continuous Improvement — running retrospectives and tracking improvements  
+  https://github.com/rhythmpatel/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-retrospective-and-continuous-improvement.md
+
+- Roles & Personas — role definitions and responsibilities used across these docs  
+  https://github.com/rhythmpatel/skills-scale-institutional-knowledge-using-copilot-spaces/blob/main/docs/octoacme-roles-and-personas.md
+
+Maintainers
+- Keep this README updated when new process documents are added or when any link changes.
+- For Copilot Spaces: add process-specific or private artifacts into .copilot/ if you want them included in the Copilot Space context.
+
+Notes
+- This README is intended as a navigational and orientation aid — each linked doc contains detailed guidance and checklists to follow during project work.


### PR DESCRIPTION
This PR adds a central README for the OctoAcme project management docs in docs/README.md.

Why
- Provides an entry point and index for the process docs in docs/.
- Summarizes OctoAcme's project management principles and lifecycle to aid onboarding and discovery.

What
- Adds docs/README.md with:
  - Brief overview of OctoAcme project management principles and lifecycle.
  - Direct links to all current docs in the docs/ folder.

Related
- Links to issue: #2

Acceptance criteria
- [x] Content aligns with existing process docs
- [x] Update improves clarity or closes a documented gap
- [x] Proposed content has been reviewed with stakeholders (if needed)

Please add @rhythmpatel as a reviewer.